### PR TITLE
Fix URI 

### DIFF
--- a/service/routes.py
+++ b/service/routes.py
@@ -42,7 +42,7 @@ def index():
 # ADD A NEW SHOPCART
 ######################################################################
 @app.route("/shopcarts", methods=["POST"])
-def create_shopcarts():
+def create_empty_shopcarts():
     """
     Creates a ShopCart
     This endpoint will create a ShopCart based the data in the body that is posted
@@ -51,21 +51,20 @@ def create_shopcarts():
     check_content_type("application/json")
     shopcart = ShopCart()
     shopcart.deserialize(request.get_json())
-    shopcart.create()
-    message = shopcart.serialize()
-    location_url = url_for("get_shopcarts", customer_id=shopcart.customer_id, 
-                                            product_id=shopcart.product_id, _external=True)
+    # shopcart.create()
+    message = {"customer_id": shopcart.customer_id}
+    location_url = url_for("get_shopcarts", customer_id=shopcart.customer_id, _external=True)
 
-    app.logger.info("Shopcart for customer [%s] for product [%s] created.", shopcart.customer_id, shopcart.product_id)
+    app.logger.info("Shopcart for customer [%s] created.", shopcart.customer_id)
     return make_response(
-        jsonify(message), status.HTTP_201_CREATED, {"Location": location_url}
+        message, status.HTTP_201_CREATED, {"Location": location_url}
     )
 
 ######################################################################
 # ADD A NEW ITEM TO SHOPCART
 ######################################################################
 @app.route("/shopcarts/<int:customer_id>/items", methods=["POST"])
-def create_shopcart_by_id(customer_id):
+def create_shopcarts_with_item(customer_id):
     """
     Add an item to an existing ShopCart 
     This endpoint will create a ShopCart based the data in the body that is posted
@@ -78,7 +77,7 @@ def create_shopcart_by_id(customer_id):
         abort(status.HTTP_400_BAD_REQUEST, "Customer ID in data must be {} as requested in URI. ".format(customer_id)) 
     shopcart.create()
     message = shopcart.serialize()
-    location_url = url_for("get_shopcarts", customer_id=shopcart.customer_id, 
+    location_url = url_for("get_shopcarts_with_item_id", customer_id=shopcart.customer_id, 
                                             product_id=shopcart.product_id, _external=True)
 
     app.logger.info("Shopcart for customer [%s] for product [%s] created.", shopcart.customer_id, shopcart.product_id)
@@ -109,7 +108,7 @@ def get_shopcarts(customer_id):
 # RETRIEVE A SHOPCART
 ######################################################################
 @app.route("/shopcarts/<int:customer_id>/items/<int:product_id>", methods=["GET"])
-def get_item_in_shopcart(customer_id, product_id):
+def get_shopcarts_with_item_id(customer_id, product_id):
     """
     Retrieve a single ShopCart
     This endpoint will return a ShopCart based on it's id

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -52,7 +52,8 @@ class TestShopCart(TestCase):
         for _ in range(count):
             test_shopcart = ShopCartFactory()
             resp = self.app.post(
-                BASE_URL, json=test_shopcart.serialize(), content_type=CONTENT_TYPE_JSON
+                f'{BASE_URL}/{test_shopcart.customer_id}/items', 
+                json=test_shopcart.serialize(), content_type=CONTENT_TYPE_JSON
             )
             self.assertEqual(
                 resp.status_code, status.HTTP_201_CREATED, "Could not create test shopcart"
@@ -72,8 +73,8 @@ class TestShopCart(TestCase):
         resp = self.app.get("/")
         self.assertEqual(resp.status_code, status.HTTP_200_OK)
 
-    def test_create_shopcart(self):
-        """Create a new shopcart"""
+    def test_create_empty_shopcart(self):
+        """Create an empty shopcart"""
         test_shopcart = ShopCartFactory()
         logging.debug(test_shopcart)
         resp = self.app.post(
@@ -85,27 +86,14 @@ class TestShopCart(TestCase):
         self.assertIsNotNone(location)
         # Check the data is correct
         new_shopcart = resp.get_json()
-        self.assertEqual(new_shopcart["name"], test_shopcart.name, "Names do not match")
-        self.assertEqual(
-            new_shopcart["price"], test_shopcart.price, "Prices do not match"
-        )
-        self.assertEqual(
-            new_shopcart["quantity"], test_shopcart.quantity, "Quantities does not match"
-        )
+        self.assertEqual(new_shopcart["customer_id"], test_shopcart.customer_id, 
+                        "Customer id do not match")
         # Check that the location header was correct
         resp = self.app.get(location, content_type=CONTENT_TYPE_JSON)
-        self.assertEqual(resp.status_code, status.HTTP_200_OK)
-        new_shopcart = resp.get_json()[0]
-        self.assertEqual(new_shopcart["name"], test_shopcart.name, "Names do not match")
-        self.assertEqual(
-            new_shopcart["price"], test_shopcart.price, "Prices do not match"
-        )
-        self.assertEqual(
-            new_shopcart["quantity"], test_shopcart.quantity, "Quantities does not match"
-        )
+        self.assertEqual(resp.status_code, status.HTTP_404_NOT_FOUND)
 
-    def test_create_shopcart_alt_route(self):
-        """Get a single ShopCart"""
+    def test_create_shopcart_with_item(self):
+        """Create a ShopCart with item in it"""
         # get the id of a shopcart
         shopcart = self._create_shopcarts(1)[0]
         test_shopcart = ShopCartFactory()
@@ -132,7 +120,7 @@ class TestShopCart(TestCase):
         # Check that the location header was correct
         resp = self.app.get(location, content_type=CONTENT_TYPE_JSON)
         self.assertEqual(resp.status_code, status.HTTP_200_OK)
-        new_shopcart = resp.get_json()[-1]
+        new_shopcart = resp.get_json()
         self.assertEqual(new_shopcart["name"], test_shopcart.name, "Names do not match")
         self.assertEqual(
             new_shopcart["price"], test_shopcart.price, "Prices do not match"
@@ -180,7 +168,8 @@ class TestShopCart(TestCase):
         # create a shopcart to update
         test_shopcart = ShopCartFactory()
         resp = self.app.post(
-            BASE_URL, json=test_shopcart.serialize(), content_type=CONTENT_TYPE_JSON
+            f'{BASE_URL}/{test_shopcart.customer_id}/items', 
+            json=test_shopcart.serialize(), content_type=CONTENT_TYPE_JSON
         )
         self.assertEqual(resp.status_code, status.HTTP_201_CREATED)
 


### PR DESCRIPTION
- use shopcarts/{customer_id}/items/{product_id} to create a new shopcart, following RESTful API convention
- allow creating empty shopcarts
- add corresponding test cases