### PR TITLE
Update manifest.yml to use buildpack

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -9,8 +9,7 @@ applications:
   hostname: nyu-shopcart-service-sp2201
   domain: us-south.cf.appdomain.cloud
   disk_quota: 1024M
-  buildpacks: 
-  - python_buildpack
+  buildpack: python_buildpack
   timeout: 180
   services:
   - ElephantSQL


### PR DESCRIPTION
Attempting to fix:

Error reading manifest file:
The following manifest fields cannot be used with legacy push: buildpacks